### PR TITLE
Use 80 port for exposed broker service

### DIFF
--- a/docs/getting-started-memory.md
+++ b/docs/getting-started-memory.md
@@ -23,7 +23,7 @@ Wait until the MemoryBroker is ready. It will inform in its status of the URL wh
 kubectl get memorybroker demo
 
 NAME   URL                                                        AGE   READY   REASON
-demo   http://demo-mb-broker.default.svc.cluster.local:8080   10s   True
+demo   http://demo-mb-broker.default.svc.cluster.local   10s   True
 ```
 
 To be able to use the broker we will create a `curl` Pod that allow us to send events inside the Kubernetes cluster.
@@ -35,7 +35,7 @@ kubectl apply -f https://raw.githubusercontent.com/triggermesh/triggermesh-core/
 It is possible now to send events to the broker address by issuing curl commands. The response for ingested events must be an `HTTP 200` which means that the broker has received it and will try to deliver them to configured triggers.
 
 ```console
-kubectl exec -ti curl -- curl -v http://demo-mb-broker.default.svc.cluster.local:8080 \
+kubectl exec -ti curl -- curl -v http://demo-mb-broker.default.svc.cluster.local \
     -X POST \
     -H "Ce-Id: 1234-abcd" \
     -H "Ce-Specversion: 1.0" \
@@ -67,7 +67,7 @@ The Trigger created above filters by CloudEvents containing `type: demo.type1` a
 Using the `curl` Pod again we can send this CloudEvent to the broker.
 
 ```console
-kubectl exec -ti curl -- curl -v http://demo-mb-broker.default.svc.cluster.local:8080 \
+kubectl exec -ti curl -- curl -v http://demo-mb-broker.default.svc.cluster.local \
     -X POST \
     -H "Ce-Id: 1234-abcd" \
     -H "Ce-Specversion: 1.0" \
@@ -107,7 +107,7 @@ kubectl delete -f https://raw.githubusercontent.com/triggermesh/triggermesh-core
 Any event that pass the filter will try to be sent to the target, and upon failing will be delivered to the DLS.
 
 ```console
-kubectl exec -ti curl -- curl -v http://demo-mb-broker.default.svc.cluster.local:8080 \
+kubectl exec -ti curl -- curl -v http://demo-mb-broker.default.svc.cluster.local \
     -X POST \
     -H "Ce-Id: 1234-abcd" \
     -H "Ce-Specversion: 1.0" \

--- a/docs/getting-started-redis.md
+++ b/docs/getting-started-redis.md
@@ -23,7 +23,7 @@ Wait until the RedisBroker is ready. It will inform in its status of the URL whe
 kubectl get redisbroker demo
 
 NAME   URL                                                        AGE   READY   REASON
-demo   http://demo-rb-broker.default.svc.cluster.local:8080   10s   True
+demo   http://demo-rb-broker.default.svc.cluster.local   10s   True
 ```
 
 To be able to use the broker we will create a Pod that allow us to send events inside the Kubernetes cluster.
@@ -35,7 +35,7 @@ kubectl apply -f https://raw.githubusercontent.com/triggermesh/triggermesh-core/
 It is possible now to send events to the broker address by issuing curl commands. The response for ingested events must be an `HTTP 200` which means that the broker has received it and will try to deliver them to configured triggers.
 
 ```console
-kubectl exec -ti curl -- curl -v http://demo-rb-broker.default.svc.cluster.local:8080 \
+kubectl exec -ti curl -- curl -v http://demo-rb-broker.default.svc.cluster.local \
     -X POST \
     -H "Ce-Id: 1234-abcd" \
     -H "Ce-Specversion: 1.0" \
@@ -67,7 +67,7 @@ The Trigger created above filters by CloudEvents containing `type: demo.type1` a
 Using the `curl` Pod again we can send this CloudEvent to the broker.
 
 ```console
-kubectl exec -ti curl -- curl -v http://demo-rb-broker.default.svc.cluster.local:8080 \
+kubectl exec -ti curl -- curl -v http://demo-rb-broker.default.svc.cluster.local \
     -X POST \
     -H "Ce-Id: 1234-abcd" \
     -H "Ce-Specversion: 1.0" \
@@ -107,7 +107,7 @@ kubectl delete -f https://raw.githubusercontent.com/triggermesh/triggermesh-core
 Any event that pass the filter will try to be sent to the target, and upon failing will be delivered to the DLS.
 
 ```console
-kubectl exec -ti curl -- curl -v http://demo-rb-broker.default.svc.cluster.local:8080 \
+kubectl exec -ti curl -- curl -v http://demo-rb-broker.default.svc.cluster.local \
     -X POST \
     -H "Ce-Id: 1234-abcd" \
     -H "Ce-Specversion: 1.0" \

--- a/docs/observable-broker.md
+++ b/docs/observable-broker.md
@@ -31,7 +31,7 @@ Wait until the RedisBroker is ready. It will inform in its status of the URL whe
 kubectl get redisbroker metrics-demo
 
 NAME   URL                                                        AGE   READY   REASON
-demo   http://metrics-demo-rb-broker.default.svc.cluster.local:8080   10s   True
+demo   http://metrics-demo-rb-broker.default.svc.cluster.local   10s   True
 ```
 
 Prometheus can be easily installed following one of this methods:
@@ -92,7 +92,7 @@ kubectl apply -f https://raw.githubusercontent.com/triggermesh/triggermesh-core/
 It is possible now to send events to the broker address by issuing curl commands. The response for ingested events must be an `HTTP 200` which means that the broker has received it and will try to deliver them to configured triggers.
 
 ```console
-kubectl exec -ti curl -- curl -v http://metrics-demo-rb-broker.default.svc.cluster.local:8080 \
+kubectl exec -ti curl -- curl -v http://metrics-demo-rb-broker.default.svc.cluster.local \
     -X POST \
     -H "Ce-Id: 1234-abcd" \
     -H "Ce-Specversion: 1.0" \

--- a/pkg/reconciler/common/reconcile_broker.go
+++ b/pkg/reconciler/common/reconcile_broker.go
@@ -28,9 +28,11 @@ const (
 	brokerResourceSuffix           = "broker"
 	brokerDeploymentComponentLabel = "broker-deployment"
 
-	// ports must be >1024 to be able to bind them
+	// container ports must be >1024 to be able to bind them
 	// in unprivileged environments.
-	defaultBrokerServicePort = 8080
+	brokerContainerPort = 8080
+
+	defaultBrokerServicePort = 80
 	metricsServicePort       = 9090
 )
 
@@ -91,13 +93,13 @@ func buildBrokerDeployment(rb eventingv1alpha1.ReconcilableBroker, sa *corev1.Se
 
 	copts := []resources.ContainerOption{
 		resources.ContainerAddArgs("start"),
-		resources.ContainerAddEnvFromValue("PORT", strconv.Itoa(int(defaultBrokerServicePort))),
+		resources.ContainerAddEnvFromValue("PORT", strconv.Itoa(int(brokerContainerPort))),
 		resources.ContainerAddEnvFromValue("BROKER_NAME", name),
 		resources.ContainerAddEnvFromFieldRef("KUBERNETES_NAMESPACE", "metadata.namespace"),
 		resources.ContainerAddEnvFromValue("KUBERNETES_BROKER_CONFIG_SECRET_NAME", secret.Name),
 		resources.ContainerAddEnvFromValue("KUBERNETES_BROKER_CONFIG_SECRET_KEY", ConfigSecretKey),
 		resources.ContainerWithImagePullPolicy(pullPolicy),
-		resources.ContainerAddPort("httpce", defaultBrokerServicePort),
+		resources.ContainerAddPort("httpce", brokerContainerPort),
 		resources.ContainerAddPort("metrics", metricsServicePort),
 	}
 
@@ -214,7 +216,7 @@ func buildBrokerService(rb eventingv1alpha1.ReconcilableBroker) *corev1.Service 
 		resources.ServiceSetType(corev1.ServiceTypeClusterIP),
 		resources.ServiceAddSelectorLabel(resources.AppComponentLabel, brokerDeploymentComponentLabel),
 		resources.ServiceAddSelectorLabel(resources.AppInstanceLabel, sn),
-		resources.ServiceAddPort("httpce", int32(brokerPort), defaultBrokerServicePort))
+		resources.ServiceAddPort("httpce", int32(brokerPort), brokerContainerPort))
 }
 
 func (r *brokerReconciler) reconcileService(ctx context.Context, rb eventingv1alpha1.ReconcilableBroker) (*corev1.Service, error) {


### PR DESCRIPTION
Due to previous PR exposed port for broker service is 8080.

That is a breaking change for people that do not resolve the broker at kubernetes, but use a URL.
Also, there was no need to change the broker from 80 to 8080 since it means no security issue at any Pod's.