### PR TITLE
Add redis cluster support

### DIFF
--- a/config/300-redisbroker.yaml
+++ b/config/300-redisbroker.yaml
@@ -56,8 +56,13 @@ spec:
                     type: object
                     properties:
                       url:
-                        description: URL of the Redis instance.
+                        description: URL of the Redis standalone instance.
                         type: string
+                      clusterURLs:
+                        description: URLs for the Redis cluster instances.
+                        type: array
+                        items:
+                          type: string
                       username:
                         description: Redis username.
                         type: object
@@ -88,8 +93,9 @@ spec:
                       tlsSkipVerify:
                         description: Skip TLS certificate verification.
                         type: boolean
-                    required:
-                    - url
+                    oneOf:
+                    - required: [url]
+                    - required: [clusterURLs]
 
                   stream:
                     description: Redis stream to be used by the broker.

--- a/pkg/apis/eventing/v1alpha1/redisbroker_types.go
+++ b/pkg/apis/eventing/v1alpha1/redisbroker_types.go
@@ -43,8 +43,11 @@ var (
 )
 
 type RedisConnection struct {
-	// Redis URL.
-	URL string `json:"url"`
+	// Redis URL for standalone instances
+	URL *string `json:"url,omitempty"`
+
+	// Redis URLs for cluster instances
+	ClusterURLs []string `json:"clusterURLs,omitempty"`
 
 	// Redis username.
 	Username *SecretValueFromSource `json:"username,omitempty"`

--- a/pkg/reconciler/redisbroker/controller.go
+++ b/pkg/reconciler/redisbroker/controller.go
@@ -20,7 +20,6 @@ import (
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
-	"knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding"
 	rolebindingsinformer "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -64,7 +63,7 @@ func NewController(
 	serviceAccountInformer := serviceaccount.Get(ctx)
 	roleBindingsInformer := rolebindingsinformer.Get(ctx)
 
-	_ = rolebinding.Get(ctx)
+	_ = rolebindingsinformer.Get(ctx)
 
 	r := &reconciler{
 		secretReconciler: common.NewSecretReconciler(ctx, secretInformer.Lister(), trgInformer.Lister()),


### PR DESCRIPTION
Redis cluster is now [supported by the broker](https://github.com/triggermesh/brokers/pull/122).

This PR exposes the parameter to enable it in a backwards compatible fashion.