### PR TITLE
Adding CA Certificate support to redis broker

### DIFF
--- a/config/300-redisbroker.yaml
+++ b/config/300-redisbroker.yaml
@@ -87,11 +87,23 @@ spec:
                                 type: string
                               key:
                                 type: string
+                      caCertificate:
+                        description: Contains a CA Certificate used to connect to Redis.
+                        type: object
+                        properties:
+                          secretKeyRef:
+                            description: A reference to a Kubernetes Secret object.
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              key:
+                                type: string
                       tlsEnabled:
                         description: Use TLS enctrypted Redis connection.
                         type: boolean
                       tlsSkipVerify:
-                        description: Skip TLS certificate verification.
+                        description: Skip TLS certificate verification. If caCertificate is set, tlsSkipVerify will default to false.
                         type: boolean
                     oneOf:
                     - required: [url]

--- a/docs/redis-broker.md
+++ b/docs/redis-broker.md
@@ -25,6 +25,10 @@ spec:
           secretKeyRef:
             name: <Kubernetes secret name>
             key: <Kubernetes secret key>
+        caCertificate: <CA certificate used to connect to redis. Optional>
+          secretKeyRef:
+            name: <Kubernetes secret name>
+            key: <Kubernetes secret key>
         tlsEnabled: <boolean that indicates if the Redis server is TLS protected. Optional, defaults to false>
         tlsSkipVerify: <boolean that skips verifying TLS certificates. Optional, defaults to false>
     stream: <Redis stream name. Optional, defaults to a combination of namespace and broker name>

--- a/pkg/apis/eventing/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/eventing/v1alpha1/deepcopy_generated.go
@@ -333,6 +333,11 @@ func (in *RedisConnection) DeepCopyInto(out *RedisConnection) {
 		*out = new(SecretValueFromSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CACertificate != nil {
+		in, out := &in.CACertificate, &out.CACertificate
+		*out = new(SecretValueFromSource)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.TLSEnabled != nil {
 		in, out := &in.TLSEnabled, &out.TLSEnabled
 		*out = new(bool)

--- a/pkg/apis/eventing/v1alpha1/redisbroker_types.go
+++ b/pkg/apis/eventing/v1alpha1/redisbroker_types.go
@@ -55,6 +55,9 @@ type RedisConnection struct {
 	// Redis password.
 	Password *SecretValueFromSource `json:"password,omitempty"`
 
+	// CA Certificate used to connect to Redis.
+	CACertificate *SecretValueFromSource `json:"caCertificate,omitempty"`
+
 	// Use TLS enctrypted connection.
 	TLSEnabled *bool `json:"tlsEnabled,omitempty"`
 

--- a/pkg/reconciler/redisbroker/reconciler.go
+++ b/pkg/reconciler/redisbroker/reconciler.go
@@ -84,12 +84,22 @@ func redisDeploymentOption(rb *eventingv1alpha1.RedisBroker, redisSvc *corev1.Se
 					rb.Spec.Redis.Connection.Password.SecretKeyRef.Key)(c)
 			}
 
+			if rb.Spec.Redis.Connection.CACertificate != nil {
+				resources.ContainerAddEnvVarFromSecret("REDIS_CA_CERTIFICATE",
+					rb.Spec.Redis.Connection.CACertificate.SecretKeyRef.Name,
+					rb.Spec.Redis.Connection.CACertificate.SecretKeyRef.Key)(c)
+			}
+
 			if rb.Spec.Redis.Connection.TLSEnabled != nil && *rb.Spec.Redis.Connection.TLSEnabled {
 				resources.ContainerAddEnvFromValue("REDIS_TLS_ENABLED", "true")(c)
 			}
 
 			if rb.Spec.Redis.Connection.TLSSkipVerify != nil && *rb.Spec.Redis.Connection.TLSSkipVerify {
-				resources.ContainerAddEnvFromValue("REDIS_TLS_SKIP_VERIFY", "true")(c)
+				tlsSkipVerifyDefault := "true"
+				if rb.Spec.Redis.Connection.CACertificate != nil {
+					tlsSkipVerifyDefault = "false"
+				}
+				resources.ContainerAddEnvFromValue("REDIS_TLS_SKIP_VERIFY", tlsSkipVerifyDefault)(c)
 			}
 
 		} else {


### PR DESCRIPTION
Adding an optional `caCertificate` field for the scenarios where Redis requires a cert - address feature request outlined here: https://github.com/triggermesh/brokers/issues/129