### PR TITLE
Fix ClusterRoleNamespaced typo

### DIFF
--- a/config/200-clusterrole-namespaced.yaml
+++ b/config/200-clusterrole-namespaced.yaml
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/part-of: triggermesh
 rules:
 - apiGroups:
-  - eveinting.triggermesh.io
+  - eventing.triggermesh.io
   resources: ["*"]
   verbs:
   - get


### PR DESCRIPTION
Replace typo `eveinting` with `eventing`