### PR TITLE
Redis: redis id tracking as opt in

### DIFF
--- a/config/300-redisbroker.yaml
+++ b/config/300-redisbroker.yaml
@@ -141,7 +141,9 @@ spec:
                     description: Maximum number of items (approximate) the Redis stream can host.
                     type: integer
                     default: 1000
-
+                  enableTrackingID:
+                    description: Whether the Redis ID for the event is added as a CloudEvents attribute. Defaults to false
+                    type: boolean
               broker:
                 description: Broker options.
                 type: object

--- a/docs/redis-broker.md
+++ b/docs/redis-broker.md
@@ -41,17 +41,19 @@ spec:
         tlsSkipVerify: <boolean that skips verifying TLS certificates. Optional, defaults to false>
     stream: <Redis stream name. Optional, defaults to a combination of namespace and broker name>
     streamMaxLen: <maximum number of items the Redis stream can host. Optional, defaults to unlimited>
+    enableTrackingID: <boolean that indicates if the Redis ID should be written as the CloudEvent attribute triggermeshbackendid>
   broker:
     port: <HTTP port for ingesting events>
     observability:
       valueFromConfigMap: <kubernetes ConfigMap that contains observability configuration>
 ```
 
-The only `RedisBroker` specific parameters are:
+The `RedisBroker` specific parameters are:
 
 - `spec.redis.connection`. When not used the broker will spin up a managed Redis Deployment. However for production scenarios that require HA and hardened security it is recommended to provide the connection to a user managed Redis instance.
 - `spec.stream` is the Redis stream name to be used by the broker. If it doesn't exists the Broker will create it.
 - `spec.streamMaxLen` is the maximum number of elements that the stream will contain.
+- `spec.enableTrackingID` when set adds the `triggermeshbackendid` CloudEvents attribute containing the Redis ID for the message to all outgoing events.
 
 The `spec.broker` section contains generic Borker parameters:
 

--- a/pkg/apis/eventing/v1alpha1/redisbroker_types.go
+++ b/pkg/apis/eventing/v1alpha1/redisbroker_types.go
@@ -80,6 +80,9 @@ type Redis struct {
 
 	// Maximum number of items the stream can host.
 	StreamMaxLen *int `json:"streamMaxLen,omitempty"`
+
+	// Whether the Redis ID for the event is added as a CloudEvents attribute.
+	EnableTrackingID *bool `json:"enableTrackingID,omitempty"`
 }
 
 // SecretValueFromSource represents the source of a secret value

--- a/pkg/reconciler/redisbroker/reconciler.go
+++ b/pkg/reconciler/redisbroker/reconciler.go
@@ -60,6 +60,10 @@ func redisDeploymentOption(rb *eventingv1alpha1.RedisBroker, redisSvc *corev1.Se
 		}
 		resources.ContainerAddEnvFromValue("REDIS_STREAM_MAX_LEN", maxLen)(c)
 
+		if rb.Spec.Redis != nil && rb.Spec.Redis.EnableTrackingID != nil && *rb.Spec.Redis.EnableTrackingID {
+			resources.ContainerAddEnvFromValue("REDIS_TRACKING_ID_ENABLED", "true")(c)
+		}
+
 		if rb.IsUserProvidedRedis() {
 
 			// Standalone connections require an address, while cluster connections require an


### PR DESCRIPTION
Redis ID tracking is not opt in.
See https://github.com/triggermesh/brokers/pull/150